### PR TITLE
fix hub.secret invalid documentation link

### DIFF
--- a/subscribers.md
+++ b/subscribers.md
@@ -777,7 +777,7 @@ You should **always** use the `https` endpoints when sending requests to Superfe
 
 #### Best Practice: use hub.secret
 
-When subscribing to a feed, you should use `hub.secret`, unless you are using https for your callback URLs. This secret will be used to compute a signature for each notification. You should always make sure these signatures match. You can [read more about that here](http://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.8) .
+When subscribing to a feed, you should use `hub.secret`, unless you are using https for your callback URLs. This secret will be used to compute a signature for each notification. You should always make sure these signatures match. You can [read more about that here](https://w3c.github.io/websub/#signing-content) .
 
 #### Best Practice: use different callback urls
 

--- a/subscribers.md
+++ b/subscribers.md
@@ -777,7 +777,7 @@ You should **always** use the `https` endpoints when sending requests to Superfe
 
 #### Best Practice: use hub.secret
 
-When subscribing to a feed, you should use `hub.secret`, unless you are using https for your callback URLs. This secret will be used to compute a signature for each notification. You should always make sure these signatures match. You can [read more about that here](https://w3c.github.io/pubsub/index.html#authenticated-content-distribution) .
+When subscribing to a feed, you should use `hub.secret`, unless you are using https for your callback URLs. This secret will be used to compute a signature for each notification. You should always make sure these signatures match. You can [read more about that here](http://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.8) .
 
 #### Best Practice: use different callback urls
 


### PR DESCRIPTION
In PubSubHubbub Notifications best practice section for hub.secret github repo link was invalid. Replaced it with correct link to pubsubhubbub documentation on github.